### PR TITLE
Updated container_name Variables for Flexibility

### DIFF
--- a/playbooks/roles/elasticsearch/defaults/main.yml
+++ b/playbooks/roles/elasticsearch/defaults/main.yml
@@ -24,6 +24,7 @@ es_memlock_override: |
 elastic_data_port: '9200'
 elastic_management_port: '9300'
 elastic_container: 'docker.elastic.co/elasticsearch/elasticsearch'
+elastic_container_name: 'rock-elasticsearch'
 elastic_yum: 'elastic'
 elastic_config_file: '/etc/elasticsearch/elasticsearch.yml'
 elastic_override_dir: '/etc/systemd/system/elasticsearch.service.d'

--- a/playbooks/roles/elasticsearch/templates/elasticsearch.compose.yml.j2
+++ b/playbooks/roles/elasticsearch/templates/elasticsearch.compose.yml.j2
@@ -4,7 +4,7 @@ version: '2'
 services:
   elastic:
     image: "{{ elastic_container }}:{{ elastic_ver }}"
-    container_name: "{{ rock_hostname }}"
+    container_name: "{{ elastic_container_name }}"
     restart: "always"
     ports:
       # TODO: This line should no longer be needed with the backend networking

--- a/playbooks/roles/filebeat/templates/filebeat-compose.yml.j2
+++ b/playbooks/roles/filebeat/templates/filebeat-compose.yml.j2
@@ -4,7 +4,7 @@ version: '2'
 services:
   filebeat:
     image: {{ filebeat_image }}:{{ filebeat_ver }}
-    container_name: rock-filebeat
+    container_name: {{ filebeat_container_name }}
     volumes:
       - {{ filebeat_config_location }}/filebeat.yml:/usr/share/filebeat/filebeat.yml
       - {{ suricata_log_location }}:{{ suricata_log_location }}

--- a/playbooks/roles/haproxy/defaults/main.yml
+++ b/playbooks/roles/haproxy/defaults/main.yml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-
+haproxy_container_name: 'rock-haproxy'
 #### HAProxy configuration variables ####
 haproxy_stats_port: '8080'
 elastic_lb_port: '9200'

--- a/playbooks/roles/haproxy/templates/haproxy-compose.yml.j2
+++ b/playbooks/roles/haproxy/templates/haproxy-compose.yml.j2
@@ -4,7 +4,7 @@ version: '2'
 services:
   haproxy:
     image: 'haproxy:latest'
-    container_name: 'haproxy'
+    container_name: "{{ haproxy_container_name }}"
     networks:
       rocknsm_outside:
         aliases:

--- a/playbooks/roles/kafka/templates/kafka-compose.yml.j2
+++ b/playbooks/roles/kafka/templates/kafka-compose.yml.j2
@@ -4,7 +4,7 @@ version: '2'
 services:
   kafka:
     image: rocknsm/kafka
-    container_name: rock-kafka
+    container_name: {{ kafka_container_name }}
     ports:
       - "9092:9092"
     volumes:

--- a/playbooks/roles/kibana/defaults/main.yml
+++ b/playbooks/roles/kibana/defaults/main.yml
@@ -17,5 +17,6 @@ kibana_ver: "{{ elastic_ver }}"
 kibana_port: '5601'
 kibana_ip: '0.0.0.0'
 kibana_image: 'docker.elastic.co/kibana/kibana'
+kibana_container_name: 'rock-kibana'
 kibana_yum: 'kibana'
 ...

--- a/playbooks/roles/kibana/templates/kibana-compose.yml.j2
+++ b/playbooks/roles/kibana/templates/kibana-compose.yml.j2
@@ -4,7 +4,7 @@ version: '2'
 services:
   kibana:
     image: "{{ kibana_image }}:{{ kibana_ver }}"
-    container_name: 'kibana'
+    container_name: "{{ kibana_container_name }}"
     ports:
       - "{{ kibana_ip }}:{{ kibana_port }}:{{ kibana_port }}"
     restart: "always"

--- a/playbooks/roles/logstash/defaults/main.yml
+++ b/playbooks/roles/logstash/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-
+logstash_container_name: 'rock-logstash'
 logstash_user: 'logstash'
 logstash_group: 'logstash'
 logstash_data_dir: "{{ rock_data_dir }}/logstash"

--- a/playbooks/roles/logstash/templates/logstash.compose.yml.j2
+++ b/playbooks/roles/logstash/templates/logstash.compose.yml.j2
@@ -2,7 +2,7 @@ version: "2"
 services:
   logstash:
     image: "docker.elastic.co/logstash/logstash:{{ elastic_ver }}"
-    container_name: logstash
+    container_name: "{{ logstash_container_name }}"
     restart: always
     #network_mode: host
     #ports:
@@ -23,4 +23,3 @@ networks:
   default:
     external:
       name: 'rocknsm_inside'
-

--- a/playbooks/roles/portainer/defaults/main.yml
+++ b/playbooks/roles/portainer/defaults/main.yml
@@ -2,7 +2,7 @@
 ---
 
 #### Portainer configuration variables ####
-# All Portainer configuration variables for Portainer install itself. 
- 
+# All Portainer configuration variables for Portainer install itself.
+portainer_container_name: 'rock-portainer'
 portainer_port: '9000'
 ...

--- a/playbooks/roles/portainer/templates/portainer-compose.yml.j2
+++ b/playbooks/roles/portainer/templates/portainer-compose.yml.j2
@@ -4,7 +4,7 @@ version: '2'
 services:
   portainer:
     image: 'portainer/portainer'
-    container_name: 'portainer'
+    container_name: "{{ portainer_container_name }}"
     ports:
       - "{{ portainer_port }}:{{ portainer_port }}"
     restart: "always"


### PR DESCRIPTION
1. Standardized "service_container_name" variables within defaults/main.yml to be 'rock-servicename'

2. Changed static container names within roles/*/templates/service-compose.yml to reflect the declared variable using {{ service_container_name }}