### PR TITLE
Adding localhost LogMappings

### DIFF
--- a/playbooks/roles/elasticsearch/templates/elasticsearch.service.j2
+++ b/playbooks/roles/elasticsearch/templates/elasticsearch.service.j2
@@ -12,6 +12,7 @@ ExecStartPre = /sbin/iptables -I INPUT 1 -p tcp --dport 9200 -j ACCEPT
 ExecStartPre = /sbin/iptables -I INPUT 1 -p tcp --dport 9300 -j ACCEPT
 
 ExecStart = /usr/bin/docker-compose -p rock -f {{ rock_compose_files }}/elasticsearch.compose.yml up
+ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-elasticsearch) /var/log/elasticsearch/docker.log"
 ExecStop  = /usr/bin/docker-compose -p rock -f {{ rock_compose_files }}/elasticsearch.compose.yml down
 
 ExecStop = /sbin/iptables -D INPUT -p tcp --dport 9200 -j ACCEPT

--- a/playbooks/roles/filebeat/defaults/main.yml
+++ b/playbooks/roles/filebeat/defaults/main.yml
@@ -5,5 +5,6 @@ filebeat_ver: "{{ elastic_ver }}"
 filebeat_image: 'docker.elastic.co/beats/filebeat'
 filebeat_container_name: 'rock-filebeat'
 filebeat_config_location: "{{ rocknsm_dir }}/filebeat"
+filebeat_log_dir: '/var/log/filebeat'
 
 ...

--- a/playbooks/roles/filebeat/tasks/main.yml
+++ b/playbooks/roles/filebeat/tasks/main.yml
@@ -14,6 +14,11 @@
     state: directory
     mode: 0754
 
+- name: 'Create filebeat log directory'
+  file:
+    path: "{{ filebeat_log_dir }}"
+    state: directory
+
 - name: "Add Filebeat configuration file"
   template:
     dest: "{{ filebeat_config_location }}/filebeat.yml"

--- a/playbooks/roles/filebeat/templates/filebeat-compose.yml.j2
+++ b/playbooks/roles/filebeat/templates/filebeat-compose.yml.j2
@@ -8,6 +8,7 @@ services:
     volumes:
       - {{ filebeat_config_location }}/filebeat.yml:/usr/share/filebeat/filebeat.yml
       - {{ suricata_log_location }}:{{ suricata_log_location }}
+      - {{ filebeat_log_dir }}:/usr/share/filebeat/logs
     networks:
       - rocknsm_inside
       - rocknsm_outside

--- a/playbooks/roles/filebeat/templates/filebeat.service.j2
+++ b/playbooks/roles/filebeat/templates/filebeat.service.j2
@@ -8,6 +8,7 @@ Requires = docker.service
 Type = simple
 
 ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/filebeat-compose.yml.j2 up
+ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-filebeat) /var/log/filebeat/docker.log"
 ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/filebeat-compose.yml.j2 down
 
 Restart=always

--- a/playbooks/roles/filebeat/templates/filebeat.service.j2
+++ b/playbooks/roles/filebeat/templates/filebeat.service.j2
@@ -7,9 +7,9 @@ Requires = docker.service
 [Service]
 Type = simple
 
-ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/filebeat-compose.yml.j2 up
+ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/filebeat-compose.yml up
 ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-filebeat) /var/log/filebeat/docker.log"
-ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/filebeat-compose.yml.j2 down
+ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/filebeat-compose.yml down
 
 Restart=always
 RestartSec=3

--- a/playbooks/roles/haproxy/defaults/main.yml
+++ b/playbooks/roles/haproxy/defaults/main.yml
@@ -1,6 +1,7 @@
 %YAML 1.1
 ---
 haproxy_container_name: 'rock-haproxy'
+haproxy_log_dir: '/var/log/haproxy'
 #### HAProxy configuration variables ####
 haproxy_stats_port: '8080'
 elastic_lb_port: '9200'

--- a/playbooks/roles/haproxy/tasks/haproxy_container.yml
+++ b/playbooks/roles/haproxy/tasks/haproxy_container.yml
@@ -28,6 +28,11 @@
     - "{{ rocknsm_dir }}/CA/private"
     - "{{ rocknsm_dir }}/CA/newcerts"
 
+- name: 'Create haproxy log directory'
+  file:
+    path: "{{ haproxy_log_dir }}"
+    state: directory
+
 - name: 'Pull official haproxy from docker hub'
   docker_image:
     name: 'haproxy:latest'
@@ -107,5 +112,5 @@
     enabled: yes
     state: started
     daemon_reload: yes
-    
+
 ...

--- a/playbooks/roles/haproxy/templates/haproxy-compose.yml.j2
+++ b/playbooks/roles/haproxy/templates/haproxy-compose.yml.j2
@@ -21,6 +21,7 @@ services:
     volumes:
       - "{{ rocknsm_dir }}/haproxy/haproxy.conf:/usr/local/etc/haproxy/haproxy.cfg"
       - "{{ rocknsm_dir }}/CA/private/haproxy.pem:/etc/ssl/private/haproxy.pem"
+      - "{{ haproxy_log_dir}}:{{ haproxy_log_dir }}"
       # Systemd volumes
       - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
     environment:

--- a/playbooks/roles/haproxy/templates/haproxy.service.j2
+++ b/playbooks/roles/haproxy/templates/haproxy.service.j2
@@ -8,8 +8,11 @@
  Type = simple
 
  ExecStart = /usr/bin/docker-compose -f {{ rocknsm_dir }}/haproxy/haproxy-compose.yml up
-
+ ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-haproxy) /var/log/haproxy/docker.log"
  ExecStop  = /usr/bin/docker-compose -f {{ rocknsm_dir }}/haproxy/haproxy-compose.yml down -v
+
+ Restart=always
+ RestartSec=3
 
  [Install]
  WantedBy = multi-user.target

--- a/playbooks/roles/kafka/defaults/main.yml
+++ b/playbooks/roles/kafka/defaults/main.yml
@@ -12,3 +12,4 @@ kafka_port: 9092
 kafka_maj_vsn: 1.0.0
 kafka_vsn: "2.12-{{ kafka_maj_vsn }}"
 kafka_install_dir: '/opt/kafka'
+kafka_log_dir: '/var/log/kafka'

--- a/playbooks/roles/kafka/tasks/main.yml
+++ b/playbooks/roles/kafka/tasks/main.yml
@@ -36,6 +36,11 @@
     state: directory
     mode: 0644
 
+- name: 'Create kafka log directory'
+  file:
+    path: "{{ kafka_log_dir }}"
+    state: directory
+
 # Install Kafkacat for the dockervm
 # TODO: Is this needed?
 #- name: Install Kafkacat package

--- a/playbooks/roles/kafka/templates/kafka-compose.yml.j2
+++ b/playbooks/roles/kafka/templates/kafka-compose.yml.j2
@@ -10,6 +10,7 @@ services:
     volumes:
       - /data/kafka:/tmp/kafka-logs
       - /opt/rocknsm/kafka/server.properties:/opt/kafka/config/server.properties
+      - "{{ kafka_log_dir }}:{{ kafka_log_dir }}"
     environment:
       KAFKA_ADVERTISED_HOST_NAME: rocksensor1.lan
       KAFKA_ZOOKEEPER_CONNECT: rock-zookeeper:2181

--- a/playbooks/roles/kafka/templates/kafka.service.j2
+++ b/playbooks/roles/kafka/templates/kafka.service.j2
@@ -8,7 +8,11 @@
  Type = simple
 
  ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/kafka-compose.yml up
+ ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-kafka) /var/log/kafka/docker.log"
  ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/kafka-compose.yml down
+
+ Restart=always
+ RestartSec=3
 
  [Install]
  WantedBy = multi-user.target

--- a/playbooks/roles/kibana/defaults/main.yml
+++ b/playbooks/roles/kibana/defaults/main.yml
@@ -19,4 +19,5 @@ kibana_ip: '0.0.0.0'
 kibana_image: 'docker.elastic.co/kibana/kibana'
 kibana_container_name: 'rock-kibana'
 kibana_yum: 'kibana'
+kibana_log_dir: '/var/log/kibana'
 ...

--- a/playbooks/roles/kibana/tasks/main.yml
+++ b/playbooks/roles/kibana/tasks/main.yml
@@ -32,6 +32,14 @@
     mode: u+rw,g+rw
     state: directory
 
+- name: 'Create Kibana log directory'
+  file:
+    owner: 1000
+    group: 1000
+    mode: u+rw,g+rw
+    path: "{{ kibana_log_dir }}"
+    state: directory
+
 - name: 'Copy Kibana compose file'
   template:
     src: 'kibana-compose.yml.j2'
@@ -46,5 +54,5 @@
     enabled: yes
     state: restarted
     daemon_reload: yes
-    
+
 ...

--- a/playbooks/roles/kibana/templates/kibana-compose.yml.j2
+++ b/playbooks/roles/kibana/templates/kibana-compose.yml.j2
@@ -10,6 +10,7 @@ services:
     restart: "always"
     volumes:
       - "{{ rock_data_dir }}/kibana/data:/data"
+      - "{{ kibana_log_dir }}:{{ kibana_log_dir }}"
     environment:
       - ELASTICSEARCH_URL="{{ es_url }}"
       - xpack.security.enabled="{{ xpack_license }}"

--- a/playbooks/roles/kibana/templates/kibana.service.j2
+++ b/playbooks/roles/kibana/templates/kibana.service.j2
@@ -8,7 +8,11 @@
  Type = simple
 
  ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/kibana-compose.yml up
+ ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-kibana) /var/log/kibana/docker.log"
  ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/kibana-compose.yml down
+
+ Restart=always
+ RestartSec=3
 
  [Install]
  WantedBy = multi-user.target

--- a/playbooks/roles/logstash/templates/logstash.service.j2
+++ b/playbooks/roles/logstash/templates/logstash.service.j2
@@ -8,6 +8,7 @@ Requires = docker.service
 Type = simple
 
 ExecStart = /usr/bin/docker-compose -p rock -f {{ rock_compose_files }}/logstash.compose.yml up
+ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-logstash) /var/log/logstash/docker.log"
 ExecStop  = /usr/bin/docker-compose -p rock -f {{ rock_compose_files }}/logstash.compose.yml down
 
 Restart=always

--- a/playbooks/roles/portainer/defaults/main.yml
+++ b/playbooks/roles/portainer/defaults/main.yml
@@ -5,4 +5,5 @@
 # All Portainer configuration variables for Portainer install itself.
 portainer_container_name: 'rock-portainer'
 portainer_port: '9000'
+portainer_log_dir: '/var/log/portainer'
 ...

--- a/playbooks/roles/portainer/tasks/main.yml
+++ b/playbooks/roles/portainer/tasks/main.yml
@@ -31,6 +31,11 @@
   with_items:
     - "{{ rocknsm_dir }}/portainer/data"
 
+- name: 'Create portainer log directory'
+  file:
+    path: '{{ portainer_log_dir }}'
+    state: directory
+
 - name: 'Copy Portainer compose file'
   template:
     src: 'portainer-compose.yml.j2'

--- a/playbooks/roles/portainer/templates/portainer-compose.yml.j2
+++ b/playbooks/roles/portainer/templates/portainer-compose.yml.j2
@@ -10,6 +10,7 @@ services:
     restart: "always"
     volumes:
       - "{{ rocknsm_dir }}/portainer:/data"
+      - "{{ portainer_log_dir }}:{{ portainer_log_dir}}"
 # Secure Docker network that cannot be connected to host directly
 networks:
   default:

--- a/playbooks/roles/portainer/templates/portainer.service.j2
+++ b/playbooks/roles/portainer/templates/portainer.service.j2
@@ -8,8 +8,11 @@ Requires = docker.service
 Type = simple
 
  ExecStart = /usr/bin/docker-compose -f {{ rocknsm_dir }}/portainer/portainer-compose.yml up
-
+ ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-portainer) /var/log/portainer/docker.log"
  ExecStop  = /usr/bin/docker-compose -f {{ rocknsm_dir }}/portainer/portainer-compose.yml down -v
+
+ Restart=always
+ RestartSec=3
 
 [Install]
 WantedBy = multi-user.target

--- a/playbooks/roles/zookeeper/defaults/main.yml
+++ b/playbooks/roles/zookeeper/defaults/main.yml
@@ -9,5 +9,6 @@
 zookeeper_port: 2181
 zookeeper_data_dir: "{{ rock_data_dir }}/zookeeper"
 zookeeper_dir: "{{ rocknsm_dir }}/zookeeper"
+zookeeper_log_dir: '/var/log/zookeeper'
 zookeeper_container: zookeeper
 zookeeper_ver: 3.4.11

--- a/playbooks/roles/zookeeper/tasks/main.yml
+++ b/playbooks/roles/zookeeper/tasks/main.yml
@@ -25,6 +25,11 @@
     owner: root
     group: root
 
+- name: 'Create Zookeeper log directory'
+  file:
+    path: "{{ zookeeper_log_dir }}"
+    state: directory
+
 - name: 'Install Zookeeper service file'
   template:
     src: 'zookeeper.service.j2'

--- a/playbooks/roles/zookeeper/templates/zookeeper-compose.yml.j2
+++ b/playbooks/roles/zookeeper/templates/zookeeper-compose.yml.j2
@@ -10,6 +10,7 @@ services:
     volumes:
       - {{ zookeeper_data_dir }}:/data
       - {{ zookeeper_dir }}/zoo.cfg:/conf/zoo.cfg
+      - {{ zookeeper_log_dir }}:{{ zookeeper_log_dir }}
 
     networks:
       - rocknsm_inside

--- a/playbooks/roles/zookeeper/templates/zookeeper.service.j2
+++ b/playbooks/roles/zookeeper/templates/zookeeper.service.j2
@@ -8,7 +8,11 @@
  Type = simple
 
  ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/zookeeper-compose.yml.j2 up
+ ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-zookeeper) /var/log/zookeeper/docker.log"
  ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/zookeeper-compose.yml.j2 down
+
+ Restart=always
+ RestartSec=3
 
  [Install]
  WantedBy = multi-user.target

--- a/playbooks/roles/zookeeper/templates/zookeeper.service.j2
+++ b/playbooks/roles/zookeeper/templates/zookeeper.service.j2
@@ -7,9 +7,9 @@
  [Service]
  Type = simple
 
- ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/zookeeper-compose.yml.j2 up
+ ExecStart = /usr/bin/docker-compose -f {{ rock_compose_files }}/zookeeper-compose.yml up
  ExecStartPost = /bin/sh -c "/bin/sleep 3; /bin/ln -sf $(docker inspect --format='{{ '{{' }}.LogPath{{ '}}' }}' rock-zookeeper) /var/log/zookeeper/docker.log"
- ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/zookeeper-compose.yml.j2 down
+ ExecStop  = /usr/bin/docker-compose -f {{ rock_compose_files }}/zookeeper-compose.yml down
 
  Restart=always
  RestartSec=3

--- a/playbooks/templates/dumpall.j2
+++ b/playbooks/templates/dumpall.j2
@@ -16,4 +16,4 @@ GROUPS Variables ("groups"):
 
 HOST Variables ("hostvars"):
 --------------------------------
-{{ hostvars | to_nice_json }} 
+{{ hostvars | to_nice_json }}


### PR DESCRIPTION
Our container application logs are not being stored in their respective default locations. Instead they are being dynamically generated outside of the container. This log can be viewed by using "docker logs <container_name>", but to help remove this minor layer of abstraction, I've created symlinks from these files to /var/log/*service* on the localhost when the docker container is created.

I have also created volume bind mounts that map to the same /var/log/*service* locations for each service that does not currently have logging enabled, so that if "in-container" logs are to be generated, they can be easily shared with the localhost.

For containers that are configured to store logs in specific locations (/usr/share/*service*/logs), I have mapped those areas to /var/log/*service*/ on the localhost. Elasticsearch and Filebeats are currently set up in this manner.

Lastly, I modified Logstash's volume bind mounts owner/group permissions from the UID/GID variables  to static numerical values of 1000 to prevent any further permission errors within the container. If this is deemed unnecessary, reject this change.

Reference: https://github.com/tfplenum/rock/issues/63