### PR TITLE
ceph installation drive pre-flight check

### DIFF
--- a/playbooks/drive_checker.yml
+++ b/playbooks/drive_checker.yml
@@ -1,0 +1,29 @@
+#   Run with: ansible-playbook -i inventory/<YOUR_INVENTORY> drive_checker.yml
+
+- name: Store hosts of 'all'
+  hosts:
+    - all
+  any_errors_fatal: True
+  connection: ssh
+
+  tasks:
+  - name: Query host to verify that the drive listed for ceph installation exists
+    command: "lsblk -o NAME"
+    register: command_result
+    changed_when: False
+    failed_when:
+     - "hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') not in command_result.stdout"
+
+  - name: Verify that the drive is a seperate disk and not a partition or optical drive
+    command: bash -c "lsblk | grep '{{ hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') }}.*disk'"
+    register: command_result
+    failed_when:
+     - "hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') not in command_result.stdout"
+    changed_when: False
+
+  - name: Verify that the drive does not contain root
+    command: bash -c "lsblk | grep '{{ hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') }}.*/'"
+    register: command_result
+    failed_when:
+     - "hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') in command_result.stdout"
+    changed_when: False

--- a/playbooks/generate_ssh_keys.yml
+++ b/playbooks/generate_ssh_keys.yml
@@ -14,6 +14,12 @@
     # for explanation
     ssh_short_known_hosts: "{{ groups['all'] | map('regex_replace','(.lan)','' ) | list }}"
 
+#This vars prompt prompts for the SSH password so you don't need --ask-pass
+  vars_prompt:
+    name: "ansible_ssh_pass"
+    prompt: "Enter the SSH pass: "
+    private: yes
+
   tasks:
 
   - name: Fail if ask-pass is missing


### PR DESCRIPTION
This file will verify that the drive listed in the inventory file contains a proper drive on the target systems to install ceph on. (exists, is a full disk, doesn't contain root)