### PR TITLE
Update sync.yml

### DIFF
--- a/playbooks/roles/chrony/tasks/sync.yml
+++ b/playbooks/roles/chrony/tasks/sync.yml
@@ -5,7 +5,7 @@
 - name: Make sure Chronyd Service is running on master
   service:
     name: chronyd
-    state: started
+    state: restarted
   when: inventory_hostname in groups['master-server']
 
 - name: Stop Chronyd Service on all nodes except master


### PR DESCRIPTION
In some circumstances, Chronyd on the master doesn't start up properly (never exposes port 123). This causes the nodes to fail with "no suitable hosts for synchronization found." Forcing a restart instead of just a start of the service on the master seems to fix it. 

![image](https://user-images.githubusercontent.com/25123724/39676175-90880b5c-512b-11e8-9f50-781e1751850a.png)
