### PR TITLE
Multiple drive check fix for root

### DIFF
--- a/playbooks/roles/common/tasks/00_preflight.yml
+++ b/playbooks/roles/common/tasks/00_preflight.yml
@@ -135,10 +135,12 @@
     msg: "The drives {{ data_disks }} do not have enough collective space to house the data you requested. You requested {{ total_space_required }} GB, which exceeds the {{ total_space_available }} GB you have on your drives."
   when: (total_space_available | int) < (total_space_required | int)
 
-# TODO: There is a bug here - it will only check the first drive provided
-- name: Verify that the drive does not contain root
-  command: bash -c "lsblk | grep '{{ hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') }}.*/'"
+# The below code will verify, per host, that every drive listed in the inventory file for that host does not contain the root directory / the OS
+- name: Verify the drives do not contain root
+  shell: "lsblk | grep '{{ item[item.rfind('/') + 1:] }}'"
+  with_items:
+    - "{{ data_disk_devices }}"
   register: command_result
   failed_when:
-   - "hostvars[ansible_host].data_disk_devices[0][hostvars[ansible_host].data_disk_devices[0].rfind('/') + 1:] | join('') in command_result.stdout"
+   - "'/' in command_result.stdout"
   changed_when: False

--- a/playbooks/roles/common/tasks/00_preflight.yml
+++ b/playbooks/roles/common/tasks/00_preflight.yml
@@ -4,6 +4,14 @@
     msg: 'Verify you have the remote-sensors group in your inventory file. It must be defined. See sample inventory. If you have no remote sensors you can define an empty group with just remote-senors: under nodes.'
   when: "'remote-sensors' not in groups"
 
+#The below code ssh's to every node from every node.
+#the -oBatchMode=yes tells SSH to fail if prompted for a password
+#without that option the ssh terminal will hang if it cannot connect via keys
+- name: Verify all nodes can SSH to each other with keys not passwords
+  shell: "ssh -oBatchMode=yes root@{{ item }}"
+  with_items: "{{ groups['nodes'] }}"
+  changed_when: false
+
 - name: ping all ips in inventory
   shell: "ping -c 1 {{ item }}"
   with_items: "{{ groups['nodes'] }}"


### PR DESCRIPTION
Fixed the "bug" that didn't allow the root drive checker to check all the listed drives for each host.