### PR TITLE
Adding Check for Elasticsearch CPUs

### DIFF
--- a/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
+++ b/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
@@ -22,5 +22,5 @@
 - name: Verify Elasticsearch Maximum Cores does not exceed total cores available.
   fail:
     msg: "You have specified a maximum number of cores for ElasticSearch that exceeds total cores available."
-  when: inventory_hostname in groups['elasticsearch'] and ( ansible_processor_vcpus > elastic_cpu_maximum ) 
+  when: inventory_hostname in groups['elasticsearch'] and ( elastic_cpu_maximum > ansible_processor_vcpus)
 ...

--- a/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
+++ b/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
@@ -22,5 +22,5 @@
 - name: Verify Elasticsearch Maximum Cores does not exceed total cores available.
   fail:
     msg: "You have specified a maximum number of cores for ElasticSearch that exceeds total cores available."
-  when: inventory_hostname in groups['elasticsearch'] and ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) > ( elastic_cpu_maximum | int) 
+  when: inventory_hostname in groups['elasticsearch'] and ( ansible_processor_vcpus > elastic_cpu_maximum ) 
 ...

--- a/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
+++ b/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
@@ -22,5 +22,5 @@
 - name: Verify Elasticsearch Maximum Cores does not exceed total cores available.
   fail:
     msg: "You have specified a maximum number of cores for ElasticSearch that exceeds total cores available."
-  when: inventory_hostname in groups['elasticsearch'] and ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) > {{ elastic_cpu_maximum }}  
+  when: inventory_hostname in groups['elasticsearch'] and ( ansible_processor_cores * ansible_processor_count ) > elastic_cpu_maximum  
 ...

--- a/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
+++ b/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
@@ -22,5 +22,5 @@
 - name: Verify Elasticsearch Maximum Cores does not exceed total cores available.
   fail:
     msg: "You have specified a maximum number of cores for ElasticSearch that exceeds total cores available."
-  when: inventory_hostname in groups['elasticsearch'] and ( ansible_processor_cores * ansible_processor_count ) > elastic_cpu_maximum  
+  when: inventory_hostname in groups['elasticsearch'] and ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) > ( elastic_cpu_maximum | int) 
 ...

--- a/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
+++ b/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
@@ -19,4 +19,8 @@
     msg: "elastic_mem (elasticsearch memory) consumes elastic_mem*2 for performance reasons. Your host has {{ ansible_memory_mb.real.total * 1024 }} and you have requested {{ elastic_mem * 2 * 1024 }}MB for Elasticsearch."
   when: inventory_hostname in groups['elasticsearch'] and (elastic_mem * 2 * 1024) > ansible_memory_mb.real.total
 
+- name: Verify Elasticsearch Maximum Cores does not exceed total cores available.
+  fail:
+    msg: "You have specified a maximum number of cores for ElasticSearch that exceeds total cores available."
+  when: inventory_hostname in groups['elasticsearch'] and ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) > {{ elastic_cpu_maximum }}  
 ...

--- a/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
+++ b/playbooks/roles/preflight_checks/tasks/20_elasticsearch.yml
@@ -22,5 +22,5 @@
 - name: Verify Elasticsearch Maximum Cores does not exceed total cores available.
   fail:
     msg: "You have specified a maximum number of cores for ElasticSearch that exceeds total cores available."
-  when: inventory_hostname in groups['elasticsearch'] and ( elastic_cpu_maximum > ansible_processor_vcpus)
+  when: inventory_hostname in groups['elasticsearch'] and ( elastic_cpu_maximum > (ansible_processor_cores * ansible_processor_count))
 ...

--- a/playbooks/roles/preflight_checks/tasks/30_minimum_hardware_check.yml
+++ b/playbooks/roles/preflight_checks/tasks/30_minimum_hardware_check.yml
@@ -32,6 +32,12 @@
     msg: "Not enough CPU Cores (2+ required)! Aborting server install."
   when: serverlocal is defined and serverlocal
 
+- assert:
+    that:
+      - ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) <= elastic_cpu_maximum
+    msg: "You have specified a number of Elastic CPU cores in excess of total cores available."
+  when: serverlocal is defined and serverlocal
+
 # Verify minimum memory and CPU Core requirements for sensor install
 - assert:
     that:

--- a/playbooks/roles/preflight_checks/tasks/30_minimum_hardware_check.yml
+++ b/playbooks/roles/preflight_checks/tasks/30_minimum_hardware_check.yml
@@ -34,7 +34,7 @@
 
 - assert:
     that:
-      - ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) <= elastic_cpu_maximum
+      - ({{ ansible_processor_cores }} * {{ ansible_processor_count }}) <= {{ elastic_cpu_maximum }}
     msg: "You have specified a number of Elastic CPU cores in excess of total cores available."
   when: serverlocal is defined and serverlocal
 


### PR DESCRIPTION
Simple check added to throw an exception if the specified number of maximum elasticsearch cores in the Inventory file exceeds the total number of cores available to the operating system.