### PR TITLE
Adding Pre-flight Check for Highlander Master

### DIFF
--- a/playbooks/roles/preflight_checks/tasks/11_configuration.yml
+++ b/playbooks/roles/preflight_checks/tasks/11_configuration.yml
@@ -1,0 +1,8 @@
+#############################################################
+# Checking that certain configuration requirements are met. #
+#############################################################
+
+- name: Verifying that only one Master Server is specified.
+  fail:
+    msg: "You have specified more than one Master Server where only one is allowed."
+  when: (groups['master-server'] | length) > 1

--- a/playbooks/roles/preflight_checks/tasks/main.yml
+++ b/playbooks/roles/preflight_checks/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - import_tasks: 05_Verify_SSH_keys.yml
 - import_tasks: 10_network.yml
+- import_tasks: 11_configuration.yml
 - import_tasks: 15_required_variables.yml
 - import_tasks: 20_elasticsearch.yml
 - import_tasks: 25_hard_drives.yml


### PR DESCRIPTION
There can only be one Master-Server; now we have a check to make sure only one is specified in the inventory file.